### PR TITLE
Support index standard for SocialDB

### DIFF
--- a/app.js
+++ b/app.js
@@ -315,8 +315,8 @@ const recursiveCleanup = (o) => {
 
 const indexValue = (indexObj, accountId, action, s, blockHeight) => {
   try {
-    const { key, data } = JSON.parse(s);
-    if (key === undefined || data === undefined) {
+    const { key, value } = JSON.parse(s);
+    if (key === undefined || value === undefined) {
       // Not a valid index.
       return;
     }
@@ -324,14 +324,14 @@ const indexValue = (indexObj, accountId, action, s, blockHeight) => {
       k: key,
       a: action
     });
-    const value = {
+    const indexValue = {
       a: accountId,
-      d: data,
+      v: value,
       b: blockHeight,
     }
     const values = indexObj[indexKey] || (indexObj[indexKey] = []);
-    values.push(value);
-    // console.log("Added index", key, value);
+    values.push(indexValue);
+    // console.log("Added index", indexKey, indexValue);
   } catch {
     // ignore failed indices.
   }
@@ -511,7 +511,7 @@ const buildIndex = (data, indexObj) => {
     return recursiveCleanup(res) || {};
   };
 
-  const stateIndex = (key, action, accounts, options) => {
+  const stateIndex = (key, action, accountId, options) => {
     const indexKey = JSON.stringify({
       k: key,
       a: action
@@ -520,14 +520,14 @@ const buildIndex = (data, indexObj) => {
     if (!values) {
       return [];
     }
-    accounts = isString(accounts) ? {[accounts] : true} : Array.isArray(accounts) ? accounts.reduce((acc, a) => {acc[a] = true; return acc;}, {}) : null;
+    const accounts = isString(accountId) ? {[accountId] : true} : Array.isArray(accountId) ? accounts.reduce((acc, a) => {acc[a] = true; return acc;}, {}) : null;
     if (accounts) {
       values = values.filter((v) => v.a in accounts);
     }
     return values.map((v) => ({
       accountId: v.a,
       blockHeight: v.b,
-      data: v.d,
+      value: v.v,
     }));
   };
 
@@ -737,10 +737,10 @@ const buildIndex = (data, indexObj) => {
       if (!key || !action) {
         throw new Error(`"key" and "action" are required`);
       }
-      const accounts = body.accounts;
+      const accountId = body.accountId;
       const options = body.options;
-      console.log("/index", key, action, accounts, options);
-      ctx.body = JSON.stringify(stateIndex(key, action, accounts, options));
+      console.log("/index", key, action, accountId, options);
+      ctx.body = JSON.stringify(stateIndex(key, action, accountId, options));
     } catch (e) {
       ctx.status = 400;
       ctx.body = `${e}`;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api-server-js",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
Support index standard: https://github.com/NearSocial/standards/pull/5

Introduce `/index` endpoint

Args:
- `key` is the inner indexed value from the standard.
- `action` is the `index_type` from the standard, e.g. in the path `index/like` the action is `like`.
- (optional) `accountId`. If given, it should either be a string or an array of account IDs to filter values by them. Otherwise, not filters by account Id.

Returns the array of matched indexed values. Ordered by `blockHeight`. E.g. 
```json
[
    {
        "accountId": "mob.near",
        "blockHeight": 78672789,
        "value": "test-value-1"
    },
    {
        "accountId": "mob.near",
        "blockHeight": 78672797,
        "value": "test-value-1"
    },
    {
        "accountId": "mob.near",
        "blockHeight": 78672974,
        "value": "test-value-3"
    }
]
```

Request example: 
```bash
http post https://api.near.social/index key:='"test-key-2"' action:='"test"' options:='{}'
```
