### PR TITLE
Introduce one block caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api-server-js",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
Caches results of queries until data changes (a new receipt is received).
It allows to return repeated common requests quickly.
For example a common query like keys of `*/widget/*`